### PR TITLE
Add Windows build supports to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,25 @@ matrix:
   include:
   - os: linux
     dist: xenial
+    before_script:
+    - pushd src/deps/projectm
+    - git apply ../projectm_fix_shader.diff
+    - "./autogen.sh"
+    - "./configure --with-pic --enable-static --enable-gles"
+    - make
+    - popd
   - os: osx
+    before_script:
+    - pushd src/deps/projectm
+    - git apply ../projectm_fix_shader.diff
+    - "./autogen.sh"
+    - "./configure --with-pic --enable-static --enable-gles"
+    - make
+    - popd
+  - os: windows
+    before_install:
+    - choco install make -y
+    - choco install zip -y
 addons:
   apt:
     packages:
@@ -32,12 +50,6 @@ install:
 - popd
 script:
 - export RACK_DIR="${HOME}"/Rack/Rack-SDK
-- pushd src/deps/projectm
-- git apply ../projectm_fix_shader.diff
-- "./autogen.sh"
-- "./configure --with-pic --enable-static --enable-gles"
-- make
-- popd
 - make dist
 
 deploy:

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ SLUG = Milkrack
 # https://vcvrack.com/manual/PluginDevelopmentTutorial.html
 VERSION = 0.6.0
 
+# Platform detection
+include $(RACK_DIR)/arch.mk
+
 # FLAGS will be passed to both the C and C++ compiler
 FLAGS +=
 CFLAGS +=
@@ -17,8 +20,15 @@ CXXFLAGS +=
 # Careful about linking to shared libraries, since you can't assume much about the user's environment and library search path.
 # Static libraries are fine.
 LDFLAGS += -fPIC
+ifdef ARCH_WIN
+	LDFLAGS += -shared -Wl,--export-all-symbols -lopengl32
+endif
 
-OBJECTS += src/deps/projectm/src/libprojectM/.libs/libprojectM.a
+ifdef ARCH_WIN
+	OBJECTS += libs/win/libprojectM/libprojectM.a
+else
+	OBJECTS += src/deps/projectm/src/libprojectM/.libs/libprojectM.a
+endif
 
 # Add .cpp and .c files to the build
 SOURCES += $(wildcard src/*.cpp)


### PR DESCRIPTION
This PR adds CI for Windows using Travis.

The builds on Windows use a prebuilt libprojectM thanks to @dizzisound's heroic efforts.